### PR TITLE
Fix null token

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -57,9 +57,10 @@ Resource.prototype._getToken = function( ) {
   var _this = this;
 
   return new Promise(function(resolve, reject) {
-    if( _this._iamport._getTokenCache() ) {
+    var token = _this._iamport._getTokenCache();
+    if( token ) {
       // return token cache
-      resolve( _this._iamport._getTokenCache() );
+      resolve( token );
     } else { 
       // refresh token and then return it
       request({
@@ -86,7 +87,12 @@ Resource.prototype._getToken = function( ) {
             }
             var token = result.response;
             _this._iamport._setTokenCache( token );
-            resolve( _this._iamport._getTokenCache() );
+            token = _this._iamport._getTokenCache();
+            if ( token ) {
+              resolve( token );
+            } else {
+              reject(new Error('Fail to refresh token'));
+            }
           });
         }
       })


### PR DESCRIPTION
결제 도중 `TypeError: Cannot read property 'access_token' of null at lib/resource.js:41:42` 에러가 떠서, 에러 발생 가능성 있는 부분을 고쳤습니다. (함수 두 번 호출할 사이에 토큰이 만료되는 경우, 서버에서 보내준 토큰 정보가 잘못된 경우)