### PR TITLE
누락되는 Querystring params 수정

### DIFF
--- a/lib/iamportMethod.js
+++ b/lib/iamportMethod.js
@@ -6,7 +6,9 @@
 
 'use strict';
 
+var querystring = require('querystring');
 var Promise = require('bluebird');
+var _ = require('lodash');
 var hasOwn = {}.hasOwnProperty;
 
 /** method 생성 함수
@@ -32,6 +34,7 @@ function iamportMethod (spec) {
     if(spec.urlParam) {
       if( hasOwn.call(param, spec.urlParam) ) {
         apiParams.push( param[spec.urlParam] );
+        param = _.omit(param, spec.urlParam);
       } else {
         return new Promise(function(resolve, reject) {
           reject(new Error('Param missing: ' + spec.urlParam));
@@ -52,6 +55,7 @@ function iamportMethod (spec) {
     API_BASE = apiParams.join('/');
 
     if( requestMethod === 'POST' ) formData = param;
+    else if (Object.keys(param).length > 0) API_BASE += '?' + querystring.stringify(param);
 
     return _this._makeRequest(requestMethod, API_BASE, formData);
   };

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
   },
   "homepage": "http://iamport.kr/",
   "dependencies": {
-    "request": "^2.68.0",
-    "bluebird": "^3.4.1"
+    "bluebird": "^3.4.1",
+    "lodash": "^4.17.2",
+    "request": "^2.68.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
API를 호출할 때 param에 추가 파라메터를 넣어도, GET 메소드 API들은 추가 파라메터가 적용되지 않습니다.

예를 들어

    iamport.payment.getByStatus({
        payment_status: 'paid',
        from: 1481786986,
        to: 1481788191,
        page: 1
    })

처럼 호출하면 payment_status 외에는 무시되어서 `https://api.iamport.kr/payments/status/paid`라고만 호출됩니다.

이런 문제들을 `https://api.iamport.kr/payments/status/paid?from=1481786986&to=1481788191&page=1`처럼 호출되도록 수정하였습니다.