### PR TITLE
인증 토큰 만료 직전 타이밍의 요청 예외처리

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -26,9 +26,10 @@ function Resource(iamport) {
 }
 
 Resource.prototype.path = '';
-Resource.prototype._makeRequest = function(method, url, formData) {
+Resource.prototype._makeRequestOnce = function(method, url, formData, options) {
+  options = options || {};
   var _this = this;
-  return this._getToken()
+  return this._getToken(options.forceRefreshToken)
     .then(function(token) {
       return new Promise(function(resolve, reject) {
         var deffered = { resolve: resolve, reject: reject };
@@ -46,6 +47,16 @@ Resource.prototype._makeRequest = function(method, url, formData) {
     });
 };
 
+Resource.prototype._makeRequest = function(method, url, formData) {
+  var _this = this;
+  return this._makeRequestOnce(method, url, formData)
+    .catch(function(err) {
+      if (err.code === 'HTTP_401') // Token might expire during sending the request. Try again with new token
+        return _this._makeRequestOnce(method, url, formData, { forceRefreshToken: true });
+      else throw err;
+    });
+};
+
 /**
  * 토큰을 발급합니다.
  * @see {@link https://api.iamport.kr/#!/authenticate/getToken}
@@ -53,11 +64,12 @@ Resource.prototype._makeRequest = function(method, url, formData) {
  * @return {promise} string access token
  * @private
  */
-Resource.prototype._getToken = function( ) {
+Resource.prototype._getToken = function(forceRefresh) {
   var _this = this;
 
   return new Promise(function(resolve, reject) {
-    var token = _this._iamport._getTokenCache();
+    var token;
+    if (!forceRefresh) token = _this._iamport._getTokenCache();
     if( token ) {
       // return token cache
       resolve( token );
@@ -75,7 +87,9 @@ Resource.prototype._getToken = function( ) {
       })
       .on('response', function(res){
         if( Resource.errorStates.indexOf(res.statusCode) >= 0 ) {
-          reject(new Error(res.statusCode));
+          var err = new Error(res.statusCode);
+          err.code = 'HTTP_' + res.statusCode;
+          reject(err);
         } else {
           res.on('data', function(body) {
             var result;
@@ -86,9 +100,8 @@ Resource.prototype._getToken = function( ) {
               return reject(e);
             }
             var token = result.response;
-            _this._iamport._setTokenCache( token );
-            token = _this._iamport._getTokenCache();
             if ( token ) {
+              _this._iamport._setTokenCache( token );
               resolve( token );
             } else {
               reject(new Error('Fail to refresh token'));
@@ -103,9 +116,11 @@ Resource.prototype._getToken = function( ) {
 
 Resource.prototype._responseHandler = function(deffered) {
   return function(res) {
-    var buffer = [];
+    var buffer = [], err;
     if( Resource.errorStates.indexOf(res.statusCode) >= 0 ) {
-      deffered.reject(new Error(res.statusCode));
+      err = new Error(res.statusCode);
+      err.code = 'HTTP_' + res.statusCode;
+      deffered.reject(err);
     } else {
       res.on('data', function(chunk) {
         buffer.push(chunk);
@@ -119,7 +134,9 @@ Resource.prototype._responseHandler = function(deffered) {
           return deffered.reject(e);
         }
         if( result.code !== 0 ) {
-          deffered.reject( new Error(result.message) );
+          err = new Error(result.message);
+          err.code = 'IAMPORT_' + result.code;
+          deffered.reject( err );
         } else {
           deffered.resolve( result.response );
         }


### PR DESCRIPTION
다음 두 가지 문제를 처리할 수 있도록 코드를 수정했습니다.

1. 올바른 토큰으로 요청을 보냈지만, 요청을 보내는 동안 토큰이 만료되어 API 서버에서 401에러가 뜨는 경우.

토큰을 강제로 갱신한 후 같은 요청을 한 번 더 시도.


2. API 클라이언트의 시간이 API 서버 시간보다 약간 빨라서, 아직 만료되지 않은 토큰을 만료된 것으로 간주하는 경우.

토큰이 만료된 것으로 판단되면, 새로운 토큰을 발급받음. 이때 서버에서 동일한 토큰을 보내주면 만료된 토큰으로 여기지 않고, 그 토큰을 그냥 사용. (이 토큰을 사용해서 401 에러가 날 경우 1번의 방법으로 해결)