### PR TITLE
법인 결제에서는 비밀번호가 필수항목이 아닙니다.

### DIFF
--- a/lib/iamportMethod.js
+++ b/lib/iamportMethod.js
@@ -45,6 +45,12 @@ function iamportMethod (spec) {
     if(spec.require && spec.require.length) {
       for(var i=0; i<spec.require.length; i++) {
         if (!hasOwn.call( param, spec.require[i] )) {
+          if(spec.require[i] === 'pwd_2digit'
+            && param['birth']
+            && param['birth'].length > 6){
+            continue;
+          }
+
           return new Promise(function(resolve, reject) {
             reject(new Error('Param missing: ' + spec.require[i]));
           });


### PR DESCRIPTION
법인 결제에서는 비밀번호가 필수항목이아니라서

검사하는 부분에서 예외처리를 했습니다.