### PR TITLE
fix - addition of required name parameter

### DIFF
--- a/lib/resources/Subscribe.js
+++ b/lib/resources/Subscribe.js
@@ -41,7 +41,7 @@ module.exports = resource.extend({
     method: 'POST',
     command: 'again',
     urlParam: null,
-    require: ['customer_uid','merchant_uid','amount']
+    require: ['customer_uid','merchant_uid','amount','name']
   }),
 
   /** method 생성


### PR DESCRIPTION
[POST] `/subscribe/payments/again` API에 name parameter가 필수항목입니다.

코드에 반영합니다.

> 참고

https://api.iamport.kr/#/